### PR TITLE
Optimize CI build caching for incremental builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,9 @@ jobs:
         path: |
           ./Swiftness/.swiftpm/
           ./Swiftness/.build/
-        key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}
+        key: ${{ runner.os }}-swift-${{ hashFiles('Swiftness/Package.resolved') }}-${{ github.sha }}
         restore-keys: |
+          ${{ runner.os }}-swift-${{ hashFiles('Swiftness/Package.resolved') }}-
           ${{ runner.os }}-swift-
     - name: Setup Swift
       uses: swift-actions/setup-swift@v2


### PR DESCRIPTION
This PR optimizes the GitHub Actions build workflow to significantly reduce build times by enabling incremental builds.

Previously, the cache key was static (or relied on a non-existent file path in the root), preventing new build artifacts from being saved to the cache. This caused a full rebuild on every push.

Changes:
1.  **Corrected `hashFiles` path:** Pointed to `Swiftness/Package.resolved` instead of `Package.resolved` to correctly detect dependency changes.
2.  **Enabled Per-Commit Caching:** Added `${{ github.sha }}` to the cache key. This ensures a new cache entry is created for every commit, preserving the build artifacts (including `.o` files) from that run.
3.  **Updated Restore Keys:** Configured `restore-keys` to fallback to the most recent cache with matching dependencies. This allows subsequent builds to reuse the previous compilation results and only rebuild changed files.

These changes should make the build process much faster for incremental changes.

---
*PR created automatically by Jules for task [2137940001114025729](https://jules.google.com/task/2137940001114025729) started by @jun92*